### PR TITLE
Fixing a link in the proposal document

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -21,7 +21,7 @@ Warning: custom
 Custom Warning Title: Unstable API
 Custom Warning Text:
   <b>The API represented in this document is under development and may change at any time.</b>
-  <p>For additional context on the use of this API please reference the <a href="https://github.com/immersive-web/webxr-ar-module/blob/master/ar-module-explainer.md">WebXR Augmented Reality Module Explainer</a>.</p>
+  <p>For additional context on the use of this API please reference the <a href="https://github.com/immersive-web/hit-test/blob/master/explainer.md">WebXR Hit-test Explainer</a>.</p>
 </pre>
 
 <pre class="link-defaults">


### PR DESCRIPTION
The proposal documentation for the hit-test api is currently pointed at the explainer doc for AR Module. This change updates the link to point to the explainer doc for the hit-test api.