### PR TITLE
Leverage extension point present in main WebXR spec

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 0dd2bba6dfda6c3168490a3a3044dd1d0b1ef8e0" name="generator">
   <link href="https://immersive-web.github.io/hit-test/" rel="canonical">
-  <meta content="db25a7d7f70781c10cb6000566d4f0d6f5258163" name="document-revision">
+  <meta content="89b207dc53ea0569bfe42cddf57b079121dfd4bf" name="document-revision">
   <link href="favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">
   <link href="favicon-96x96.png" rel="icon" sizes="96x96" type="image/png">
 <style>
@@ -1678,7 +1678,7 @@ Parts of this work may be from another specification document.  If so, those par
   <a class="n" data-link-type="idl-name" href="https://immersive-web.github.io/webxr/#xrpose" id="ref-for-xrpose"><c- n>XRPose</c-></a>? <a class="idl-code" data-link-type="method" href="#dom-xrhittestresult-getpose" id="ref-for-dom-xrhittestresult-getpose"><c- g>getPose</c-></a>(<a class="n" data-link-type="idl-name" href="https://immersive-web.github.io/webxr/#xrspace" id="ref-for-xrspace③"><c- n>XRSpace</c-></a> <dfn class="idl-code" data-dfn-for="XRHitTestResult/getPose(baseSpace)" data-dfn-type="argument" data-export id="dom-xrhittestresult-getpose-basespace-basespace"><code><c- g>baseSpace</c-></code><a class="self-link" href="#dom-xrhittestresult-getpose-basespace-basespace"></a></dfn>);
 };
 </pre>
-   <p>A <code class="idl"><a data-link-type="idl" href="#xrhittestresult" id="ref-for-xrhittestresult">XRHitTestResult</a></code> contains single result of a hit test. It encapsulates information about the intersection point of the ray used to perform the hit test with user’s environment as understood by the underlying <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xrsession-xr-device" id="ref-for-xrsession-xr-device">XR device</a>.</p>
+   <p>A <code class="idl"><a data-link-type="idl" href="#xrhittestresult" id="ref-for-xrhittestresult">XRHitTestResult</a></code> contains single result of a hit test. It encapsulates information about the intersection point of the ray used to perform the hit test with user’s environment as understood by the underlying <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xr-device" id="ref-for-xr-device">XR device</a>.</p>
    <p>Each <code class="idl"><a data-link-type="idl" href="#xrhittestresult" id="ref-for-xrhittestresult①">XRHitTestResult</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="XRHitTestResult" data-dfn-type="dfn" data-noexport id="xrhittestresult-frame">frame</dfn> which is an <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webxr/#xrframe-interface" id="ref-for-xrframe-interface">XRFrame</a></code> for which the result was computed.</p>
    <p>Each <code class="idl"><a data-link-type="idl" href="#xrhittestresult" id="ref-for-xrhittestresult②">XRHitTestResult</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="XRHitTestResult" data-dfn-type="dfn" data-noexport id="xrhittestresult-native-origin">native origin</dfn>. This native origin defines new coordinate system whose Y axis represents the surface’s normal vector at the intersection point.</p>
    <div class="algorithm" data-algorithm="create-hit-test-result">
@@ -1687,7 +1687,11 @@ Parts of this work may be from another specification document.  If so, those par
      <li data-md>
       <p>Let <var>hitTestResult</var> be a new <code class="idl"><a data-link-type="idl" href="#xrhittestresult" id="ref-for-xrhittestresult③">XRHitTestResult</a></code>.</p>
      <li data-md>
-      <p>Query <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xrsession-xr-device" id="ref-for-xrsession-xr-device①">XR device</a> for <a data-link-type="dfn" href="#native-entity-type" id="ref-for-native-entity-type">native entity type</a>, <var>nativeEntityType</var>, of the <var>nativeResult</var>.</p>
+      <p>Let <var>session</var> be <var>frame</var>’s <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#dom-xrframe-session" id="ref-for-dom-xrframe-session">session</a>.</p>
+     <li data-md>
+      <p>Let <var>device</var> be <var>session</var>’s <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xrsession-xr-device" id="ref-for-xrsession-xr-device">XR device</a>.</p>
+     <li data-md>
+      <p>Query <var>device</var> for <a data-link-type="dfn" href="#native-entity-type" id="ref-for-native-entity-type">native entity type</a>, <var>nativeEntityType</var>, of the <var>nativeResult</var>.</p>
      <li data-md>
       <p><a data-link-type="dfn" href="#convert-from-native-entity-type" id="ref-for-convert-from-native-entity-type">Convert from native entity type</a> <var>nativeEntityType</var> to <var>entityType</var>.</p>
      <li data-md>
@@ -1732,6 +1736,8 @@ Parts of this work may be from another specification document.  If so, those par
     <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="XRSession" data-dfn-type="method" data-export id="dom-xrsession-requesthittestsource"><code>requestHitTestSource(<var>options</var>)</code></dfn> method, when invoked on an <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webxr/#xrsession-interface" id="ref-for-xrsession-interface④">XRSession</a></code> <var>session</var>, MUST run the following steps:</p>
     <ol>
      <li data-md>
+      <p>Add <a data-link-type="dfn" href="#compute-hit-test-results" id="ref-for-compute-hit-test-results">compute hit test results</a> algorithm to <var>session</var>’s <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates" id="ref-for-xrsession-list-of-frame-updates">list of frame updates</a> if it was not already added.</p>
+     <li data-md>
       <p>Let <var>promise</var> be <a data-link-type="dfn" href="https://heycam.github.io/webidl/#a-new-promise" id="ref-for-a-new-promise">a new Promise</a>.</p>
      <li data-md>
       <p>Validate that <var>options</var> dictionary contains <code class="idl"><a data-link-type="idl" href="#dom-xrhittestoptionsinit-space" id="ref-for-dom-xrhittestoptionsinit-space②">space</a></code> key with a value of type <code class="idl"><a data-link-type="idl" href="https://immersive-web.github.io/webxr/#xrspace" id="ref-for-xrspace⑤">XRSpace</a></code> - if not, <a data-link-type="dfn" href="https://heycam.github.io/webidl/#reject" id="ref-for-reject">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror">TypeError</a></code> and abort these steps.</p>
@@ -1752,15 +1758,18 @@ Parts of this work may be from another specification document.  If so, those par
     </ol>
    </div>
    <h2 class="heading settled" data-level="6" id="computing-hit-test-results"><span class="secno">6. </span><span class="content">Computing hit test results</span><a class="self-link" href="#computing-hit-test-results"></a></h2>
-   <p class="issue" id="issue-9819eab4"><a class="self-link" href="#issue-9819eab4"></a> Add extension point to the main spec, in "xr animation frame" algorithm.</p>
    <p>Every time the user agent processes <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xr-animation-frame" id="ref-for-xr-animation-frame">XR animation frame</a> for <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webxr/#xrsession-interface" id="ref-for-xrsession-interface⑤">XRSession</a></code>, it needs to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="compute-hit-test-results">compute hit test results</dfn>. This MUST happen prior to invoking any of the callbacks from <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#list-of-animation-frame-callbacks" id="ref-for-list-of-animation-frame-callbacks">list of animation frame callbacks</a> of a given <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webxr/#xrsession-interface" id="ref-for-xrsession-interface⑥">XRSession</a></code>.</p>
    <div class="algorithm" data-algorithm="compute-hit-test-results">
-    <p>In order to <a data-link-type="dfn" href="#compute-hit-test-results" id="ref-for-compute-hit-test-results">compute hit test results</a> for a given <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webxr/#xrframe-interface" id="ref-for-xrframe-interface④">XRFrame</a></code> <var>frame</var>, for each hit test source, <var>hitTestSource</var>, that is present in <code class="idl"><a data-link-type="idl" href="https://immersive-web.github.io/webxr/#dom-xrframe-session" id="ref-for-dom-xrframe-session">session</a></code>'s <a data-link-type="dfn" href="#xrsession-set-of-active-hit-test-sources" id="ref-for-xrsession-set-of-active-hit-test-sources③">set of active hit test sources</a>, the user agent MUST perform the following steps:</p>
+    <p>In order to <a data-link-type="dfn" href="#compute-hit-test-results" id="ref-for-compute-hit-test-results①">compute hit test results</a> for a given <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/webxr/#xrframe-interface" id="ref-for-xrframe-interface④">XRFrame</a></code> <var>frame</var>, for each hit test source, <var>hitTestSource</var>, that is present in <code class="idl"><a data-link-type="idl" href="https://immersive-web.github.io/webxr/#dom-xrframe-session" id="ref-for-dom-xrframe-session①">session</a></code>'s <a data-link-type="dfn" href="#xrsession-set-of-active-hit-test-sources" id="ref-for-xrsession-set-of-active-hit-test-sources③">set of active hit test sources</a>, the user agent MUST perform the following steps:</p>
     <ol>
      <li data-md>
-      <p>Let the <var>entityTypes</var> be the <var>hitTestSource</var>’s <a data-link-type="dfn" href="#xrhittestsource-entity-types" id="ref-for-xrhittestsource-entity-types①">entity types</a>.</p>
+      <p>Let <var>entityTypes</var> be the <var>hitTestSource</var>’s <a data-link-type="dfn" href="#xrhittestsource-entity-types" id="ref-for-xrhittestsource-entity-types①">entity types</a>.</p>
      <li data-md>
-      <p>Query the <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xrsession-xr-device" id="ref-for-xrsession-xr-device②">XR device</a>'s tracking system for <var>hitTestSource</var>’s <a data-link-type="dfn" href="#xrhittestsource-native-origin" id="ref-for-xrhittestsource-native-origin①">native origin</a>'s latest <var>coordinates</var>.</p>
+      <p>Let <var>session</var> be <var>frame</var>’s <code class="idl"><a data-link-type="idl" href="https://immersive-web.github.io/webxr/#dom-xrframe-session" id="ref-for-dom-xrframe-session②">session</a></code>.</p>
+     <li data-md>
+      <p>Let <var>device</var> be the <var>session</var>’s <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xrsession-xr-device" id="ref-for-xrsession-xr-device①">XR device</a>.</p>
+     <li data-md>
+      <p>Query the <var>device</var>’s tracking system for <var>hitTestSource</var>’s <a data-link-type="dfn" href="#xrhittestsource-native-origin" id="ref-for-xrhittestsource-native-origin①">native origin</a>'s latest <var>coordinates</var>.</p>
      <li data-md>
       <p>Interpret <var>hitTestSource</var>’s <a data-link-type="dfn" href="#xrhittestsource-offset-ray" id="ref-for-xrhittestsource-offset-ray①">offset ray</a>, <var>offsetRay</var>, as if expressed relative to <var>coordinates</var> and using that interpretation, perform <a data-link-type="dfn" href="#native-hit-test" id="ref-for-native-hit-test">native hit test</a> obtaining <a data-link-type="dfn" href="#native-hit-test-result" id="ref-for-native-hit-test-result①">native hit test results</a> <var>nativeResults</var>.</p>
      <li data-md>
@@ -1884,14 +1893,14 @@ Parts of this work may be from another specification document.  If so, those par
     </ol>
    </div>
    <div class="algorithm" data-algorithm="distance-along-ray">
-    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="distance-along-the-ray">distance along the ray</dfn>, <var>distance</var>, from <code class="idl"><a data-link-type="idl" href="#xrray" id="ref-for-xrray①③">XRRay</a></code> <var>ray</var> to any entity <var>entity</var> is defined such that <code><var>ray</var>.origin + <var>ray</var>.direction * <var>distance</var></code> results in a point beloning to the entity <var>entity</var>, <var>distance</var> is non-negative, and there does not exist a smaller value of <var>distance</var> for the above predicate to still hold. It is up to the <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xrsession-xr-device" id="ref-for-xrsession-xr-device③">XR device</a> to define the meaning of "point belonging to an entity".</p>
+    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="distance-along-the-ray">distance along the ray</dfn>, <var>distance</var>, from <code class="idl"><a data-link-type="idl" href="#xrray" id="ref-for-xrray①③">XRRay</a></code> <var>ray</var> to any entity <var>entity</var> is defined such that <code><var>ray</var>.origin + <var>ray</var>.direction * <var>distance</var></code> results in a point beloning to the entity <var>entity</var>, <var>distance</var> is non-negative, and there does not exist a smaller value of <var>distance</var> for the above predicate to still hold. It is up to the <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xr-device" id="ref-for-xr-device①">XR device</a> to define the meaning of "point belonging to an entity".</p>
    </div>
    <h2 class="heading settled" data-level="9" id="native-device-concepts"><span class="secno">9. </span><span class="content">Native device concepts</span><a class="self-link" href="#native-device-concepts"></a></h2>
    <section class="non-normative">
     <p>User agents implementing hit test API must have a way of obtaining information about user’s environment from underlying XR device. This section attempts to describe requirements and concepts related to native capabilities of the device and is by neccesity sufficiently under-specified to leave ample room for different underlying frameworks / devices.</p>
    </section>
    <h3 class="heading settled" data-level="9.1" id="native-hit-test-section"><span class="secno">9.1. </span><span class="content">Native hit test</span><a class="self-link" href="#native-hit-test-section"></a></h3>
-   <p>In this specification it is assumed that <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xrsession-xr-device" id="ref-for-xrsession-xr-device④">XR device</a> exposes a way for the user agent to perform a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="native-hit-test">native hit test</dfn> that satisfies the following requirements:</p>
+   <p>In this specification it is assumed that <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xr-device" id="ref-for-xr-device②">XR device</a> exposes a way for the user agent to perform a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="native-hit-test">native hit test</dfn> that satisfies the following requirements:</p>
    <ul>
     <li data-md>
      <p>Accepts a 3D ray that will be tested against user’s environment.</p>
@@ -1900,7 +1909,7 @@ Parts of this work may be from another specification document.  If so, those par
    </ul>
    <p class="note" role="note"><span>Note:</span> For devices that do not expose the hit test functionality natively, it might still be possible for user agents to implement this specification by leveraging other ways of obtaining the information about user’s environment that might be exposed by the XR device.</p>
    <h3 class="heading settled" data-level="9.2" id="native-entity-type-section"><span class="secno">9.2. </span><span class="content">Native entity type</span><a class="self-link" href="#native-entity-type-section"></a></h3>
-   <p><a data-link-type="dfn" href="#native-hit-test-result" id="ref-for-native-hit-test-result②">Native hit test results</a> returned by <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xrsession-xr-device" id="ref-for-xrsession-xr-device⑤">XR device</a> should contain information about the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="native entity type" data-noexport id="native-entity-type">type of the entity</dfn> used to compute the result. Such native types might consist of, but not be limited to:</p>
+   <p><a data-link-type="dfn" href="#native-hit-test-result" id="ref-for-native-hit-test-result②">Native hit test results</a> returned by <a data-link-type="dfn" href="https://www.w3.org/TR/webxr/#xr-device" id="ref-for-xr-device③">XR device</a> should contain information about the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="native entity type" data-noexport id="native-entity-type">type of the entity</dfn> used to compute the result. Such native types might consist of, but not be limited to:</p>
    <ul>
     <li data-md>
      <p>Point - signifies that hit test result was computed based on characteristic points found in user’s environment.</p>
@@ -2274,7 +2283,7 @@ Parts of this work may be from another specification document.  If so, those par
   <aside class="dfn-panel" data-for="term-for-dom-xrframe-session">
    <a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-xrframe-session">6. Computing hit test results</a>
+    <li><a href="#ref-for-dom-xrframe-session①">6. Computing hit test results</a> <a href="#ref-for-dom-xrframe-session②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-xrframe-interface">
@@ -2316,6 +2325,12 @@ Parts of this work may be from another specification document.  If so, those par
    <a href="https://www.w3.org/TR/webxr/#list-of-animation-frame-callbacks">https://www.w3.org/TR/webxr/#list-of-animation-frame-callbacks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-animation-frame-callbacks">6. Computing hit test results</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-xrsession-list-of-frame-updates">
+   <a href="https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates">https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-xrsession-list-of-frame-updates">5. Requesting hit test</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-xrrigidtransform-matrix">
@@ -2364,11 +2379,8 @@ Parts of this work may be from another specification document.  If so, those par
   <aside class="dfn-panel" data-for="term-for-xrsession-xr-device">
    <a href="https://www.w3.org/TR/webxr/#xrsession-xr-device">https://www.w3.org/TR/webxr/#xrsession-xr-device</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-xrsession-xr-device">4.1. XRHitTestResult</a> <a href="#ref-for-xrsession-xr-device①">(2)</a>
-    <li><a href="#ref-for-xrsession-xr-device②">6. Computing hit test results</a>
-    <li><a href="#ref-for-xrsession-xr-device③">8.1. XRRay</a>
-    <li><a href="#ref-for-xrsession-xr-device④">9.1. Native hit test</a>
-    <li><a href="#ref-for-xrsession-xr-device⑤">9.2. Native entity type</a>
+    <li><a href="#ref-for-xrsession-xr-device">4.1. XRHitTestResult</a>
+    <li><a href="#ref-for-xrsession-xr-device①">6. Computing hit test results</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -2423,14 +2435,15 @@ Parts of this work may be from another specification document.  If so, those par
      <li><span class="dfn-paneled" id="term-for-xrspace-effective-origin" style="color:initial">effective origin</span>
      <li><span class="dfn-paneled" id="term-for-identity-transform" style="color:initial">identity transform</span>
      <li><span class="dfn-paneled" id="term-for-list-of-animation-frame-callbacks" style="color:initial">list of animation frame callbacks</span>
+     <li><span class="dfn-paneled" id="term-for-xrsession-list-of-frame-updates" style="color:initial">list of frame updates</span>
      <li><span class="dfn-paneled" id="term-for-dom-xrrigidtransform-matrix" style="color:initial">matrix <small>(for XRRigidTransform)</small></span>
      <li><span class="dfn-paneled" id="term-for-xrspace-native-origin" style="color:initial">native origin</span>
      <li><span class="dfn-paneled" id="term-for-normalize" style="color:initial">normalize</span>
      <li><span class="dfn-paneled" id="term-for-xrspace-origin-offset" style="color:initial">origin offset</span>
      <li><span class="dfn-paneled" id="term-for-populate-the-pose" style="color:initial">populate the pose</span>
-     <li><span class="dfn-paneled" id="term-for-xrspace-session" style="color:initial">session</span>
+     <li><span class="dfn-paneled" id="term-for-xrspace-session" style="color:initial">session <small>(for XRSpace)</small></span>
      <li><span class="dfn-paneled" id="term-for-xr-animation-frame" style="color:initial">xr animation frame</span>
-     <li><span class="dfn-paneled" id="term-for-xrsession-xr-device" style="color:initial">xr device</span>
+     <li><span class="dfn-paneled" id="term-for-xrsession-xr-device" style="color:initial">xr device <small>(for XRSession)</small></span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -2492,7 +2505,6 @@ Parts of this work may be from another specification document.  If so, those par
 </pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
-   <div class="issue"> Add extension point to the main spec, in "xr animation frame" algorithm.<a href="#issue-9819eab4"> ↵ </a></div>
    <div class="issue"> Improve - this probably needs to ensure that frame is active, etc.<a href="#issue-e3d68193"> ↵ </a></div>
    <div class="issue"> Decide if we need to specify other axes of the coordinate system defined by hit test result’s native origin to maintain compatibility between different implementations &amp; differrent AR frameworks.<a href="#issue-4d2e55aa"> ↵ </a></div>
   </div>
@@ -2688,7 +2700,8 @@ Parts of this work may be from another specification document.  If so, those par
   <aside class="dfn-panel" data-for="compute-hit-test-results">
    <b><a href="#compute-hit-test-results">#compute-hit-test-results</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-compute-hit-test-results">6. Computing hit test results</a>
+    <li><a href="#ref-for-compute-hit-test-results">5. Requesting hit test</a>
+    <li><a href="#ref-for-compute-hit-test-results①">6. Computing hit test results</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-xrframe-gethittestresults">

--- a/index.bs
+++ b/index.bs
@@ -17,6 +17,10 @@ Editor: Piotr Bialecki 114482, Google http://google.com/, bialpio@google.com
 Abstract: Describes a method for performing hit tests against real world geometry to be used with the WebXR Device API.
 </pre>
 
+<pre class="link-defaults">
+spec:webxr device api - level 1; type:dfn; for:/; text:xr device
+</pre>
+
 <pre class="anchors">
 spec: WebXR Device API - Level 1; urlPrefix: https://www.w3.org/TR/webxr/#
     type: interface; text: XRSession; url: xrsession-interface
@@ -25,8 +29,13 @@ spec: WebXR Device API - Level 1; urlPrefix: https://www.w3.org/TR/webxr/#
         type: dfn; text: native origin; url: xrspace-native-origin
         type: dfn; text: origin offset; url: xrspace-origin-offset
         type: dfn; text: effective origin; url: xrspace-effective-origin
+    for: XRSession;
+        type: dfn; text: list of frame updates; url: xrsession-list-of-frame-updates
+        type: dfn; text: XR device; url: xrsession-xr-device
     type: interface; text: XRFrame; url: xrframe-interface
-    type: dfn; text: XR device; url: xrsession-xr-device
+    for: XRFrame;
+        type: dfn; text: session; url: dom-xrframe-session
+    type: dfn; text: XR device; url: xr-device
     type: dfn; text: XR animation frame; url: xr-animation-frame
     type: dfn; text: list of animation frame callbacks; url: list-of-animation-frame-callbacks
     type: callback; text: XRFrameRequestCallback; url: callbackdef-xrframerequestcallback
@@ -203,7 +212,9 @@ Each {{XRHitTestResult}} has an associated <dfn for="XRHitTestResult">native ori
 
 In order to <dfn>create a hit test result</dfn> given {{XRFrame}} |frame|, array of {{XRHitTestTrackableType}} |entityTypes|, and [=native hit test result=] |nativeResult|, the user agent MUST run the following steps:
     1. Let |hitTestResult| be a new {{XRHitTestResult}}.
-    1. Query [=/XR device=] for [=native entity type=], |nativeEntityType|, of the |nativeResult|.
+    1. Let |session| be |frame|'s [=XRFrame/session=].
+    1. Let |device| be |session|'s [=XRSession/XR device=].
+    1. Query |device| for [=native entity type=], |nativeEntityType|, of the |nativeResult|.
     1. [=Convert from native entity type=] |nativeEntityType| to |entityType|.
     1. If |entityType| is <code>null</code> or is not present in |entityTypes| array, return <code>null</code> and abort these steps.
     1. Set |hitTestResult|'s [=XRHitTestResult/frame=] to |frame|.
@@ -248,6 +259,7 @@ The application can <dfn>request hit test</dfn> using {{XRSession}}'s {{XRSessio
 
 The <dfn method for="XRSession">requestHitTestSource(|options|)</dfn> method, when invoked on an {{XRSession}} |session|, MUST run the following steps:
 
+  1. Add [=compute hit test results=] algorithm to |session|'s [=XRSession/list of frame updates=] if it was not already added.
   1. Let |promise| be [=a new Promise=].
   1. Validate that |options| dictionary contains {{XRHitTestOptionsInit/space}} key with a value of type {{XRSpace}} - if not, [=/reject=] |promise| with a {{TypeError}} and abort these steps.
   1. Initialize |space| of type {{XRSpace}} to the value contained in |options| dictionary under the {{XRHitTestOptionsInit/space}} key.
@@ -263,15 +275,15 @@ The <dfn method for="XRSession">requestHitTestSource(|options|)</dfn> method, wh
 Computing hit test results {#computing-hit-test-results}
 ==========================
 
-Issue: Add extension point to the main spec, in "xr animation frame" algorithm.
-
 Every time the user agent processes [=/XR animation frame=] for {{XRSession}}, it needs to <dfn>compute hit test results</dfn>. This MUST happen prior to invoking any of the callbacks from [=/list of animation frame callbacks=] of a given {{XRSession}}.
 
 <div class="algorithm" data-algorithm="compute-hit-test-results">
 
 In order to [=compute hit test results=] for a given {{XRFrame}} |frame|, for each hit test source, |hitTestSource|, that is present in {{XRFrame/session}}'s [=XRSession/set of active hit test sources=], the user agent MUST perform the following steps:
-    1. Let the |entityTypes| be the |hitTestSource|'s [=XRHitTestSource/entity types=].
-    1. Query the [=/XR device=]'s tracking system for |hitTestSource|'s [=XRHitTestSource/native origin=]'s latest |coordinates|.
+    1. Let |entityTypes| be the |hitTestSource|'s [=XRHitTestSource/entity types=].
+    1. Let |session| be |frame|'s {{XRFrame/session}}.
+    1. Let |device| be the |session|'s  [=XRSession/XR device=].
+    1. Query the |device|'s tracking system for |hitTestSource|'s [=XRHitTestSource/native origin=]'s latest |coordinates|.
     1. Interpret |hitTestSource|'s [=XRHitTestSource/offset ray=], |offsetRay|, as if expressed relative to |coordinates| and using that interpretation, perform [=native hit test=] obtaining [=native hit test results=] |nativeResults|.
     1. Let |hitTestResults| be an empty [=/list=].
     1. Given the |frame| and |entityTypes|, for each native hit test result |nativeResult| in |nativeResults|, perform the following steps:


### PR DESCRIPTION
Use the `XRSession`'s `list of frame updates` for computing hit test results.

Fixes inline spec issue.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/hit-test/pull/62.html" title="Last updated on Dec 5, 2019, 7:36 PM UTC (c9abb5d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/hit-test/62/b279fc5...c9abb5d.html" title="Last updated on Dec 5, 2019, 7:36 PM UTC (c9abb5d)">Diff</a>