### PR TITLE
Gate hit test behind feature policy

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -31,7 +31,8 @@ spec: WebXR Device API - Level 1; urlPrefix: https://www.w3.org/TR/webxr/#
         type: dfn; text: session; url: xrspace-session
     type: interface; text: XRSession; url: xrsession-interface
     for: XRSession;
-        type: dfn; text: list of enabled features; url: xr-session-list-of-enabled-features
+        type: dfn; text: ended; url: ended
+        type: dfn; text: list of enabled features; url: xrsession-list-of-enabled-features
         type: dfn; text: list of frame updates; url: xrsession-list-of-frame-updates
         type: dfn; text: XR device; url: xrsession-xr-device
     type: interface; text: XRFrame; url: xrframe-interface
@@ -46,6 +47,7 @@ spec: WebXR Device API - Level 1; urlPrefix: https://www.w3.org/TR/webxr/#
     type: callback; text: XRFrameRequestCallback; url: callbackdef-xrframerequestcallback
     type: dfn; text: capable of supporting; url: capable-of-supporting
     type: dfn; text: feature descriptor; url: feature-descriptor
+    type: dfn; text: feature policy; url: feature-policy
     type: dfn; text: identity transform; url: identity-transform
     type: dfn; text: inline XR device; url: inline-xr-device
     type: dfn; text: list of active XR input sources; url: list-of-active-xr-input-sources
@@ -138,6 +140,8 @@ Feature descriptor {#hit-test-feature-descriptor}
 In order for the applications to signal their interest in performing hit testing during a session, the session must be requested with appropriate [=feature descriptor=]. The string <dfn>hit-test</dfn> is introduced by this module as a new valid feature descriptor for hit test feature.
 
 A device is [=capable of supporting=] the hit test feature if the device exposes a [=native hit test=] capability. The [=inline XR device=] MUST NOT be treated as [=capable of supporting=] the hit test feature.
+
+The hit test feature is subject to [=feature policy=] and requires <code>"xr-spatial-tracking"</code> policy to be allowed on the requesting document's origin.
 
 Hit test options {#hit-test-options}
 ================
@@ -425,6 +429,7 @@ The <dfn method for="XRSession">requestHitTestSource(|options|)</dfn> method, wh
 
   1. Let |promise| be [=a new Promise=].
   1. If [=hit-test=] feature descriptor is not [=list/contain|contained=] in the |session|'s [=XRSession/list of enabled features=], [=/reject=] |promise| with {{NotSupportedError}} and abort these steps.
+  1. If |session|’s [=XRSession/ended=] value is <code>true</code>, throw an {{InvalidStateError}} and abort these steps.
   1. The user agent MAY [=/reject=] |promise| with {{NotAllowedError}} and abort these steps if there is a [=unreasonable number of requests=].
   1. Add [=compute all hit test results=] algorithm to |session|'s [=XRSession/list of frame updates=] if it is not already present there.
   1. [=Create a hit test source=], |hitTestSource|, with |session|, |options|' {{XRHitTestOptionsInit/space}}, |options|' [=XRHitTestOptionsInit/effective entityTypes=] and |options|' [=XRHitTestOptionsInit/effective offsetRay=].
@@ -440,6 +445,7 @@ The <dfn method for="XRSession">requestHitTestSourceForTransientInput(|options|)
 
   1. Let |promise| be [=a new Promise=].
   1. If [=hit-test=] feature descriptor is not [=list/contain|contained=] in the |session|'s [=XRSession/list of enabled features=], [=/reject=] |promise| with {{NotSupportedError}} and abort these steps.
+  1. If |session|’s [=XRSession/ended=] value is <code>true</code>, throw an {{InvalidStateError}} and abort these steps.
   1. The user agent MAY [=/reject=] |promise| with {{NotAllowedError}} and abort these steps if there is a [=unreasonable number of requests=].
   1. Add [=compute all hit test results=] algorithm to |session|'s [=XRSession/list of frame updates=] if it is not already present there.
   1. [=Create a hit test source for transient input=], |hitTestSource|, with |session|, |options|' {{XRTransientInputHitTestOptionsInit/profile}}, |options|' [=XRHitTestOptionsInit/effective entityTypes=] and |options|' [=XRHitTestOptionsInit/effective offsetRay=].


### PR DESCRIPTION
Hit test should be gated by the same feature policy that the majority of
other features already use ("xr-spatial-tracking").

Other changes:
- session needs to reject requests to hit test if it has already ended.

@mounirlamouri, @Manishearth, @thetuvix - please take a look.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/hit-test/pull/77.html" title="Last updated on Jan 23, 2020, 11:04 PM UTC (dcc33c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/hit-test/77/e1eee8d...dcc33c0.html" title="Last updated on Jan 23, 2020, 11:04 PM UTC (dcc33c0)">Diff</a>