### PR TITLE
XRRay.matrix should be initialized as null for XRRay(transform) as well

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -585,6 +585,7 @@ The <dfn constructor for="XRRay">XRRay(|transform|)</dfn> constructor MUST perfo
   1. Transform |ray|'s {{XRRay/origin}} by premultiplying the |transform|'s {{XRRigidTransform/matrix}} and set |ray| to the result.
   1. Transform |ray|'s {{XRRay/direction}} by premultiplying the |transform|'s {{XRRigidTransform/matrix}} and set |ray| to the result.
   1. [=Normalize=] the {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} components of |ray|'s {{XRRay/direction}}.
+  1. Initialize |ray|'s [=XRRay/matrix=] to <code>null</code>.
   1. Return |ray|.
 
 </div>


### PR DESCRIPTION
Fixes #79


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/takahirox/hit-test/pull/80.html" title="Last updated on Feb 26, 2020, 10:44 PM UTC (5591ee8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/hit-test/80/ba8c4cc...takahirox:5591ee8.html" title="Last updated on Feb 26, 2020, 10:44 PM UTC (5591ee8)">Diff</a>