### PR TITLE
Fix webidl for XRRay

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -565,10 +565,11 @@ interface XRRay {
 The <dfn constructor for="XRRay">XRRay(|origin|, |direction|)</dfn> constructor MUST perform the following steps when invoked:
 
   1. Let |ray| be a new {{XRRay}}.
+  1. If |direction|'s {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} values are all zero, throw a {{TypeError}} and abort these steps.
   1. Initialize |ray|'s {{XRRay/origin}} to <code>{ x: 0.0, y: 0.0, z: 0.0, w: 1.0 }</code>.
   1. Initialize |ray|'s {{XRRay/direction}} to <code>{ x: 0.0, y: 0.0, z: -1.0, w: 0.0 }</code>.
   1. Initialize |ray|'s {{XRRay/origin}}’s {{DOMPointReadOnly/x}} value to |origin|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |origin|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |origin|'s {{DOMPointInit/z}}.
-  1. If at least one of |direction|'s {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} values are non-zero, initialize |ray|'s {{XRRay/direction}}’s {{DOMPointReadOnly/x}} value to |direction|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |direction|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |direction|'s {{DOMPointInit/z}}.
+ initialize |ray|'s {{XRRay/direction}}’s {{DOMPointReadOnly/x}} value to |direction|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |direction|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |direction|'s {{DOMPointInit/z}}.
   1. [=Normalize=] the {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} components of |ray|'s {{XRRay/direction}}.
   1. Initialize |ray|'s [=XRRay/matrix=] to <code>null</code>.
   1. Return |ray|.

--- a/index.bs
+++ b/index.bs
@@ -550,10 +550,10 @@ An {{XRRay}} is a geometric ray described by an {{XRRay/origin}} point and {{XRR
 An {{XRRay}} contains a <dfn for=XRRay>matrix</dfn> which is a [=/matrix=].
 
 <script type="idl">
-[SecureContext, Exposed=Window,
- Constructor(optional DOMPointInit origin, optional DOMPointInit direction),
- Constructor(XRRigidTransform transform)]
+[SecureContext, Exposed=Window]
 interface XRRay {
+  constructor(optional DOMPointInit origin = {}, optional DOMPointInit direction = {});
+  constructor(XRRigidTransform transform);
   [SameObject] readonly attribute DOMPointReadOnly origin;
   [SameObject] readonly attribute DOMPointReadOnly direction;
   [SameObject] readonly attribute Float32Array matrix;
@@ -567,8 +567,8 @@ The <dfn constructor for="XRRay">XRRay(|origin|, |direction|)</dfn> constructor 
   1. Let |ray| be a new {{XRRay}}.
   1. Initialize |ray|'s {{XRRay/origin}} to <code>{ x: 0.0, y: 0.0, z: 0.0, w: 1.0 }</code>.
   1. Initialize |ray|'s {{XRRay/direction}} to <code>{ x: 0.0, y: 0.0, z: -1.0, w: 0.0 }</code>.
-  1. If |origin| was set, initialize |ray|'s {{XRRay/origin}}’s {{DOMPointReadOnly/x}} value to |origin|'s x dictionary member, {{DOMPointReadOnly/y}} value to |origin|'s y dictionary member, and {{DOMPointReadOnly/z}} value to |origin|'s z dictionary member.
-  1. If |direction| was set, initialize |ray|'s {{XRRay/direction}}’s {{DOMPointReadOnly/x}} value to |direction|'s x dictionary member, {{DOMPointReadOnly/y}} value to |direction|'s y dictionary member, and {{DOMPointReadOnly/z}} value to |direction|'s z dictionary member.
+  1. Initialize |ray|'s {{XRRay/origin}}’s {{DOMPointReadOnly/x}} value to |origin|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |origin|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |origin|'s {{DOMPointInit/z}}.
+  1. If at least one of |direction|'s {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} values are non-zero, initialize |ray|'s {{XRRay/direction}}’s {{DOMPointReadOnly/x}} value to |direction|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |direction|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |direction|'s {{DOMPointInit/z}}.
   1. [=Normalize=] the {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} components of |ray|'s {{XRRay/direction}}.
   1. Initialize |ray|'s [=XRRay/matrix=] to <code>null</code>.
   1. Return |ray|.

--- a/index.bs
+++ b/index.bs
@@ -565,11 +565,10 @@ interface XRRay {
 The <dfn constructor for="XRRay">XRRay(|origin|, |direction|)</dfn> constructor MUST perform the following steps when invoked:
 
   1. Let |ray| be a new {{XRRay}}.
-  1. If |direction|'s {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} values are all zero, throw a {{TypeError}} and abort these steps.
   1. Initialize |ray|'s {{XRRay/origin}} to <code>{ x: 0.0, y: 0.0, z: 0.0, w: 1.0 }</code>.
   1. Initialize |ray|'s {{XRRay/direction}} to <code>{ x: 0.0, y: 0.0, z: -1.0, w: 0.0 }</code>.
   1. Initialize |ray|'s {{XRRay/origin}}’s {{DOMPointReadOnly/x}} value to |origin|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |origin|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |origin|'s {{DOMPointInit/z}}.
- initialize |ray|'s {{XRRay/direction}}’s {{DOMPointReadOnly/x}} value to |direction|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |direction|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |direction|'s {{DOMPointInit/z}}.
+  1. If at least one of |direction|'s {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} values are non-zero, initialize |ray|'s {{XRRay/direction}}’s {{DOMPointReadOnly/x}} value to |direction|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |direction|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |direction|'s {{DOMPointInit/z}}.
   1. [=Normalize=] the {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} components of |ray|'s {{XRRay/direction}}.
   1. Initialize |ray|'s [=XRRay/matrix=] to <code>null</code>.
   1. Return |ray|.


### PR DESCRIPTION
- `[Constructor]` is now `constructor()`
 - Optional dictionary arguments need to be initialized to `{}` in the webidl https://github.com/heycam/webidl/pull/750
 - Given that the dictionary argument is initialized to `{}`, we can't check if it's null, we have to check if all fields are zero (which we should have been checking anyway).


r? @bialpio


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/hit-test/pull/83.html" title="Last updated on Apr 9, 2020, 5:23 AM UTC (78104e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/hit-test/83/a9aca35...Manishearth:78104e7.html" title="Last updated on Apr 9, 2020, 5:23 AM UTC (78104e7)">Diff</a>