### PR TITLE
Update XRRay vector constructor to use correct webidl semantics

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -542,6 +542,19 @@ When the <dfn method for="XRFrame">getHitTestResultsForTransientInput(|hitTestSo
 Geometric primitives {#geometric-primitives}
 ====================
 
+XRRayDirectionInit {#xr-ray-direction-init-dictionary}
+--------------------
+
+An {{XRRayDirectionInit}} dictionary represents a direction vector to be passed to the {{XRRay(origin, direction)}} constructor.
+
+<script type="idl">
+dictionary XRRayDirectionInit {
+  double x = 0;
+  double y = 0;
+  double z = -1;
+};
+</script>
+
 XRRay {#xrray-interface}
 -----
 
@@ -552,7 +565,7 @@ An {{XRRay}} contains a <dfn for=XRRay>matrix</dfn> which is a [=/matrix=].
 <script type="idl">
 [SecureContext, Exposed=Window]
 interface XRRay {
-  constructor(optional DOMPointInit origin = {}, optional DOMPointInit direction = {});
+  constructor(optional DOMPointInit origin = {}, optional XRRayDirectionInit direction = {});
   constructor(XRRigidTransform transform);
   [SameObject] readonly attribute DOMPointReadOnly origin;
   [SameObject] readonly attribute DOMPointReadOnly direction;
@@ -567,8 +580,9 @@ The <dfn constructor for="XRRay">XRRay(|origin|, |direction|)</dfn> constructor 
   1. Let |ray| be a new {{XRRay}}.
   1. Initialize |ray|'s {{XRRay/origin}} to <code>{ x: 0.0, y: 0.0, z: 0.0, w: 1.0 }</code>.
   1. Initialize |ray|'s {{XRRay/direction}} to <code>{ x: 0.0, y: 0.0, z: -1.0, w: 0.0 }</code>.
+  1. If all of |direction|'s {{XRRayDirectionInit/x}}, {{XRRayDirectionInit/y}}, and {{XRRayDirectionInit/z}} are zero, throw a {{TypeError}} and abort these steps.
   1. Initialize |ray|'s {{XRRay/origin}}’s {{DOMPointReadOnly/x}} value to |origin|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |origin|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |origin|'s {{DOMPointInit/z}}.
-  1. If at least one of |direction|'s {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} values are non-zero, initialize |ray|'s {{XRRay/direction}}’s {{DOMPointReadOnly/x}} value to |direction|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |direction|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |direction|'s {{DOMPointInit/z}}.
+  1. Initialize |ray|'s {{XRRay/direction}}’s {{DOMPointReadOnly/x}} value to |direction|'s {{XRRayDirectionInit/x}}, {{DOMPointReadOnly/y}} value to |direction|'s {{XRRayDirectionInit/y}}, and {{DOMPointReadOnly/z}} value to |direction|'s {{XRRayDirectionInit/z}}.
   1. [=Normalize=] the {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} components of |ray|'s {{XRRay/direction}}.
   1. Initialize |ray|'s [=XRRay/matrix=] to <code>null</code>.
   1. Return |ray|.

--- a/index.bs
+++ b/index.bs
@@ -581,6 +581,7 @@ The <dfn constructor for="XRRay">XRRay(|origin|, |direction|)</dfn> constructor 
   1. Initialize |ray|'s {{XRRay/origin}} to <code>{ x: 0.0, y: 0.0, z: 0.0, w: 1.0 }</code>.
   1. Initialize |ray|'s {{XRRay/direction}} to <code>{ x: 0.0, y: 0.0, z: -1.0, w: 0.0 }</code>.
   1. If all of |direction|'s {{XRRayDirectionInit/x}}, {{XRRayDirectionInit/y}}, and {{XRRayDirectionInit/z}} are zero, throw a {{TypeError}} and abort these steps.
+  1. If |origin|'s {{DOMPointInit/w}} is not 1.0, throw a {{TypeError}} and abort these steps.
   1. Initialize |ray|'s {{XRRay/origin}}’s {{DOMPointReadOnly/x}} value to |origin|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |origin|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |origin|'s {{DOMPointInit/z}}.
   1. Initialize |ray|'s {{XRRay/direction}}’s {{DOMPointReadOnly/x}} value to |direction|'s {{XRRayDirectionInit/x}}, {{DOMPointReadOnly/y}} value to |direction|'s {{XRRayDirectionInit/y}}, and {{DOMPointReadOnly/z}} value to |direction|'s {{XRRayDirectionInit/z}}.
   1. [=Normalize=] the {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} components of |ray|'s {{XRRay/direction}}.

--- a/index.bs
+++ b/index.bs
@@ -552,6 +552,7 @@ dictionary XRRayDirectionInit {
   double x = 0;
   double y = 0;
   double z = -1;
+  double w = 0;
 };
 </script>
 
@@ -581,6 +582,7 @@ The <dfn constructor for="XRRay">XRRay(|origin|, |direction|)</dfn> constructor 
   1. Initialize |ray|'s {{XRRay/origin}} to <code>{ x: 0.0, y: 0.0, z: 0.0, w: 1.0 }</code>.
   1. Initialize |ray|'s {{XRRay/direction}} to <code>{ x: 0.0, y: 0.0, z: -1.0, w: 0.0 }</code>.
   1. If all of |direction|'s {{XRRayDirectionInit/x}}, {{XRRayDirectionInit/y}}, and {{XRRayDirectionInit/z}} are zero, throw a {{TypeError}} and abort these steps.
+  1. If |direction|'s {{XRRayDirectionInit/w}} is not 0.0, throw a {{TypeError}} and abort these steps.
   1. If |origin|'s {{DOMPointInit/w}} is not 1.0, throw a {{TypeError}} and abort these steps.
   1. Initialize |ray|'s {{XRRay/origin}}’s {{DOMPointReadOnly/x}} value to |origin|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |origin|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |origin|'s {{DOMPointInit/z}}.
   1. Initialize |ray|'s {{XRRay/direction}}’s {{DOMPointReadOnly/x}} value to |direction|'s {{XRRayDirectionInit/x}}, {{DOMPointReadOnly/y}} value to |direction|'s {{XRRayDirectionInit/y}}, and {{DOMPointReadOnly/z}} value to |direction|'s {{XRRayDirectionInit/z}}.

--- a/index.bs
+++ b/index.bs
@@ -550,10 +550,10 @@ An {{XRRay}} is a geometric ray described by an {{XRRay/origin}} point and {{XRR
 An {{XRRay}} contains a <dfn for=XRRay>matrix</dfn> which is a [=/matrix=].
 
 <script type="idl">
-[SecureContext, Exposed=Window,
- Constructor(optional DOMPointInit origin, optional DOMPointInit direction),
- Constructor(XRRigidTransform transform)]
+[SecureContext, Exposed=Window]
 interface XRRay {
+  constructor(optional DOMPointInit origin = {}, optional DOMPointInit direction = {});
+  constructor(XRRigidTransform transform);
   [SameObject] readonly attribute DOMPointReadOnly origin;
   [SameObject] readonly attribute DOMPointReadOnly direction;
   [SameObject] readonly attribute Float32Array matrix;
@@ -567,8 +567,8 @@ The <dfn constructor for="XRRay">XRRay(|origin|, |direction|)</dfn> constructor 
   1. Let |ray| be a new {{XRRay}}.
   1. Initialize |ray|'s {{XRRay/origin}} to <code>{ x: 0.0, y: 0.0, z: 0.0, w: 1.0 }</code>.
   1. Initialize |ray|'s {{XRRay/direction}} to <code>{ x: 0.0, y: 0.0, z: -1.0, w: 0.0 }</code>.
-  1. If |origin| was set, initialize |ray|'s {{XRRay/origin}}’s {{DOMPointReadOnly/x}} value to |origin|'s x dictionary member, {{DOMPointReadOnly/y}} value to |origin|'s y dictionary member, and {{DOMPointReadOnly/z}} value to |origin|'s z dictionary member.
-  1. If |direction| was set, initialize |ray|'s {{XRRay/direction}}’s {{DOMPointReadOnly/x}} value to |direction|'s x dictionary member, {{DOMPointReadOnly/y}} value to |direction|'s y dictionary member, and {{DOMPointReadOnly/z}} value to |direction|'s z dictionary member.
+  1. Initialize |ray|'s {{XRRay/origin}}’s {{DOMPointReadOnly/x}} value to |origin|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |origin|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |origin|'s {{DOMPointInit/z}}.
+  1. If at least one of |direction|'s {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} values are non-zero, initialize |ray|'s {{XRRay/direction}}’s {{DOMPointReadOnly/x}} value to |direction|'s {{DOMPointInit/x}}, {{DOMPointReadOnly/y}} value to |direction|'s {{DOMPointInit/y}}, and {{DOMPointReadOnly/z}} value to |direction|'s {{DOMPointInit/z}}.
   1. [=Normalize=] the {{DOMPointReadOnly/x}}, {{DOMPointReadOnly/y}}, and {{DOMPointReadOnly/z}} components of |ray|'s {{XRRay/direction}}.
   1. Initialize |ray|'s [=XRRay/matrix=] to <code>null</code>.
   1. Return |ray|.


### PR DESCRIPTION
Fixes https://github.com/immersive-web/hit-test/issues/84

This adds a new initializer type so that the defaults work correctly.

This also throws an error for non-1 `w` coordinates for the `origin`, similar to `XRRigidTransform`.


r? @bialpio


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/hit-test/pull/85.html" title="Last updated on Apr 10, 2020, 8:31 AM UTC (9dba19d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/hit-test/85/a9aca35...Manishearth:9dba19d.html" title="Last updated on Apr 10, 2020, 8:31 AM UTC (9dba19d)">Diff</a>