### PR TITLE
fix code block broken in the website

### DIFF
--- a/hit-testing-explainer.md
+++ b/hit-testing-explainer.md
@@ -205,6 +205,7 @@ This feature is blocked by default for third-party contexts and can be controlle
 
 ## Appendix A: Proposed partial IDL
 This is a partial IDL and is considered additive to the core IDL found in the main [explainer](https://github.com/immersive-web/webxr/blob/master/explainer.md).
+
 ```webidl
 //
 // Session
@@ -280,4 +281,4 @@ interface XRRay {
   [SameObject] readonly attribute DOMPointReadOnly direction;
   [SameObject] readonly attribute Float32Array matrix;
 };
-
+```


### PR DESCRIPTION
Hello.
I found a code block broken in explainer document page like below.
![image](https://user-images.githubusercontent.com/11372210/164913745-0fe9dc08-43f6-4fbb-bcb8-45fef172629d.png)

Then, I fixed it.