### PR TITLE
Stop using FrozenArray in dictionaries

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -176,7 +176,7 @@ An {{XRHitTestOptionsInit}} dictionary represents a set of configurable values t
 <script type="idl">
 dictionary XRHitTestOptionsInit {
   required XRSpace space;
-  FrozenArray<XRHitTestTrackableType> entityTypes;
+  sequence<XRHitTestTrackableType> entityTypes;
   XRRay offsetRay;
 };
 </script>
@@ -203,7 +203,7 @@ An {{XRTransientInputHitTestOptionsInit}} dictionary represents a set of configu
 <script type="idl">
 dictionary XRTransientInputHitTestOptionsInit {
   required DOMString profile;
-  FrozenArray<XRHitTestTrackableType> entityTypes;
+  sequence<XRHitTestTrackableType> entityTypes;
   XRRay offsetRay;
 };
 </script>
@@ -647,7 +647,7 @@ The <dfn>distance along the ray</dfn>, |distance|, from {{XRRay}} |ray| to any e
 
 </div>
 
-Native device concepts {#native-device-concepts} 
+Native device concepts {#native-device-concepts}
 ======================
 
 <section class="non-normative">


### PR DESCRIPTION
Fixes #116

Same reasoning as https://github.com/immersive-web/webxr/pull/1369. Accepting `FrozenArray`s as inputs is confusing and non-sensical, and their presence here is likely copy-paster error. Replacing with `sequence`. Does not (yet) replace uses where `FrozenArray`s are returned. (See #117)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/hit-test/pull/118.html" title="Last updated on Jun 5, 2024, 8:10 PM UTC (c3e894e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/hit-test/118/16c4842...c3e894e.html" title="Last updated on Jun 5, 2024, 8:10 PM UTC (c3e894e)">Diff</a>