### PR TITLE
Return sequences instead of FrozenArrays

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -507,8 +507,8 @@ Obtaining hit test results {#obtaining-hit-test-results}
 
 <script type="idl">
 partial interface XRFrame {
-  FrozenArray<XRHitTestResult> getHitTestResults(XRHitTestSource hitTestSource);
-  FrozenArray<XRTransientInputHitTestResult> getHitTestResultsForTransientInput(XRTransientInputHitTestSource hitTestSource);
+  sequence<XRHitTestResult> getHitTestResults(XRHitTestSource hitTestSource);
+  sequence<XRTransientInputHitTestResult> getHitTestResultsForTransientInput(XRTransientInputHitTestSource hitTestSource);
 };
 </script>
 


### PR DESCRIPTION
Fixes #117

As agreed on in today's call, having `getHitTestResults` and `getHitTestResultsForTransientInput` return `FrozenArray`s isn't being used for optimization purposes, and is unusual relative to other Web APIs. This PR changes them both to sequences, which shouldn't result in any user-facing breaking behavior.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/hit-test/pull/119.html" title="Last updated on Jun 11, 2024, 9:09 PM UTC (08b505a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/hit-test/119/16c4842...08b505a.html" title="Last updated on Jun 11, 2024, 9:09 PM UTC (08b505a)">Diff</a>